### PR TITLE
feat: add support for fifo topics/queues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -170,11 +170,12 @@ async fn create_queue<T: AsRef<str>>(queue: T) -> Result<(SQSQueueURL, SQSQueueA
         .queue_name(&queue)
         .attributes(QueueAttributeName::Policy, &policy);
 
-    // Set FIFO queue attributes if this is a FIFO queue
     if ResourceName::is_fifo(&queue) {
         create_queue_builder = create_queue_builder
             .attributes(QueueAttributeName::FifoQueue, "true")
-            .attributes(QueueAttributeName::ContentBasedDeduplication, "false");
+            // ContentBasedDeduplication enabled so we don't need to require MessageDeduplicationIds in the message,
+            // but they can still be used to override the default deduplication.
+            .attributes(QueueAttributeName::ContentBasedDeduplication, "true");
     }
 
     let resp = match create_queue_builder.send().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use once_cell::sync::OnceCell;
 // Project-Level Imports
 pub(crate) use cli::CLIArgs;
 pub(crate) use types::{
-    EnvName, PinnConfig, SNSTopicARN, SQSQueueARN, SQSQueueConfig, SQSQueueURL,
+    EnvName, PinnConfig, ResourceName, SNSTopicARN, SQSQueueARN, SQSQueueConfig, SQSQueueURL,
 };
 
 pub(crate) mod cli;
@@ -37,30 +37,34 @@ pub(crate) static CLI_ARGS: OnceCell<AtomicCell<CLIArgs>> = OnceCell::new();
 // <editor-fold desc="// SNS Topic Utilities ...">
 
 async fn create_topic<T: AsRef<str>>(topic: T) -> Result<SNSTopicARN, Terminator> {
-    println!("Ensuring existence of topic: \"{}\"", topic.as_ref());
+    let topic_name = topic.as_ref();
+    println!("Ensuring existence of topic: \"{}\"", topic_name);
 
+    let is_fifo_topic = ResourceName::is_fifo(topic_name);
     let topic: String = if CLUSTER_ENV.get().unwrap().borrow().is_unknown() {
-        topic.as_ref().to_string()
+        topic_name.to_string()
     } else {
         let suffix = CLUSTER_ENV.get().unwrap().borrow().as_suffix().to_string();
+        let suffixed_name = ResourceName::with_suffix(topic_name, &suffix);
         println!(
-            "Suffixing topic \"{}\" as \"{}-{}\" per in-cluster configuration...",
-            topic.as_ref(),
-            topic.as_ref(),
-            suffix
+            "Suffixing topic \"{}\" as \"{}\" per in-cluster configuration...",
+            topic_name, &suffixed_name
         );
-        format!("{}-{}", topic.as_ref(), suffix,)
+        suffixed_name
     };
 
-    let resp = match SNS_CLIENT
+    let mut create_topic_builder = SNS_CLIENT
         .get()
         .unwrap()
         .borrow()
         .create_topic()
-        .name(&topic)
-        .send()
-        .await
-    {
+        .name(&topic);
+
+    if ResourceName::is_fifo(&topic) {
+        create_topic_builder = create_topic_builder.attributes("FifoTopic", "true");
+    }
+
+    let resp = match create_topic_builder.send().await {
         Ok(response) => response,
         Err(error) => {
             println!("Could not create topic due to error:\n----- Create '{}' Error -----\n{:#?}\n----- Create '{}' Error -----\n", &topic, &error, &topic, );
@@ -86,20 +90,20 @@ async fn create_topic<T: AsRef<str>>(topic: T) -> Result<SNSTopicARN, Terminator
 // <editor-fold desc="// SQS Queue Utilities ...">
 
 async fn create_queue<T: AsRef<str>>(queue: T) -> Result<(SQSQueueURL, SQSQueueARN), Terminator> {
-    println!("Ensuring existence of queue: \"{}\"", queue.as_ref());
+    let queue_name = queue.as_ref();
+    println!("Ensuring existence of queue: \"{}\"", queue_name);
 
     let suffix = CLUSTER_ENV.get().unwrap().borrow().as_suffix().to_string();
 
     let queue: String = if CLUSTER_ENV.get().unwrap().borrow().is_unknown() {
-        queue.as_ref().to_string()
+        queue_name.to_string()
     } else {
+        let suffixed_name = ResourceName::with_suffix(queue_name, &suffix);
         println!(
-            "Suffixing queue \"{}\" as \"{}-{}\" per in-cluster configuration...",
-            queue.as_ref(),
-            queue.as_ref(),
-            suffix
+            "Suffixing queue \"{}\" as \"{}\" per in-cluster configuration...",
+            queue_name, &suffixed_name
         );
-        format!("{}-{}", queue.as_ref(), suffix,)
+        suffixed_name
     };
 
     // If a usable region and account id were provided,
@@ -113,6 +117,12 @@ async fn create_queue<T: AsRef<str>>(queue: T) -> Result<(SQSQueueURL, SQSQueueA
 
     let policy: String = match (&aws_region, &aws_account_id) {
         (Some(region), Some(account_id)) => {
+            let source_arn_pattern = if ResourceName::is_fifo(&queue) {
+                format!("arn:aws:sns:{region}:{account_id}:*-{suffix}.fifo")
+            } else {
+                format!("arn:aws:sns:{region}:{account_id}:*-{suffix}")
+            };
+
             format!(
                 r#"{{
         "Version": "2008-10-17",
@@ -123,7 +133,7 @@ async fn create_queue<T: AsRef<str>>(queue: T) -> Result<(SQSQueueURL, SQSQueueA
                 "Resource": "arn:aws:sqs:{region}:{account_id}:{queue}",
                 "Condition": {{
                     "ArnLike": {{
-                        "aws:SourceArn": "arn:aws:sns:{region}:{account_id}:*-{suffix}"
+                        "aws:SourceArn": "{source_arn_pattern}"
                     }}
                 }},
                 "Principal": {{
@@ -139,8 +149,7 @@ async fn create_queue<T: AsRef<str>>(queue: T) -> Result<(SQSQueueURL, SQSQueueA
                 "Resource": "arn:aws:sqs:{region}:{account_id}:{queue}"
             }}
         ]
-    }}"#
-            )
+    }}"#)
         }
         _ => {
             let env = CLUSTER_ENV.get().unwrap().borrow();
@@ -154,16 +163,22 @@ async fn create_queue<T: AsRef<str>>(queue: T) -> Result<(SQSQueueURL, SQSQueueA
         }
     };
 
-    let resp = match SQS_CLIENT
+    let mut create_queue_builder = SQS_CLIENT
         .get()
         .unwrap()
         .borrow()
         .create_queue()
         .queue_name(&queue)
-        .attributes(QueueAttributeName::Policy, &policy)
-        .send()
-        .await
-    {
+        .attributes(QueueAttributeName::Policy, &policy);
+
+    // Set FIFO queue attributes if this is a FIFO queue
+    if ResourceName::is_fifo(&queue) {
+        create_queue_builder = create_queue_builder
+            .attributes(QueueAttributeName::FifoQueue, "true")
+            .attributes(QueueAttributeName::ContentBasedDeduplication, "false");
+    }
+
+    let resp = match create_queue_builder.send().await {
         Ok(response) => response,
         Err(error) => {
             return handle_create_queue_error(error, queue).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,6 @@ async fn create_topic<T: AsRef<str>>(topic: T) -> Result<SNSTopicARN, Terminator
     let topic_name = topic.as_ref();
     println!("Ensuring existence of topic: \"{}\"", topic_name);
 
-    let is_fifo_topic = ResourceName::is_fifo(topic_name);
     let topic: String = if CLUSTER_ENV.get().unwrap().borrow().is_unknown() {
         topic_name.to_string()
     } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,6 +88,30 @@ impl<T: AsRef<str>> From<T> for EnvName {
 
 // </editor-fold desc="// EnvName ...">
 
+// <editor-fold desc="// FIFO Utilities ...">
+
+pub(crate) struct ResourceName;
+
+impl ResourceName {
+    pub fn is_fifo<T: AsRef<str>>(name: T) -> bool {
+        name.as_ref().ends_with(".fifo")
+    }
+
+
+    pub fn with_suffix<T: AsRef<str>>(name: T, suffix: &str) -> String {
+        let name = name.as_ref();
+        if Self::is_fifo(name) {
+            // must end in .fifo, so env suffix must come before
+            let base_name = &name[..name.len() - 5];
+            format!("{}-{}.fifo", base_name, suffix)
+        } else {
+            format!("{}-{}", name, suffix)
+        }
+    }
+}
+
+// </editor-fold desc="// FIFO Utilities ...">
+
 // <editor-fold desc="// SQSQueueConfig ...">
 
 #[derive(Clone, Debug, Default, Deserialize)]


### PR DESCRIPTION
Please follow our [PR Documentation and Review Guidelines](https://docs.run.relay.cool/development-practices/pr-documentation-and-review-guidelines) for submitting or reviewing a PR

### Description
Adds support for services configuring fifo topics/queues. 

### Related issue(s)
https://technologyadvice.atlassian.net/browse/TRC-2267

### Related PR(s)

### How to test / repro
Tested locally with example ConfigMap yaml 
```
test-queue:
  topics:
    - test-standard-topic
    - test-fifo-topic.fifo

test-fifo-queue.fifo:
  topics:
    - test-fifo-topic.fifo
    - another-fifo-topic.fifo

unsubscribed:
  topics:
    - standalone-fifo-topic.fifo
    - standalone-standard-topic
 ```

#### Results (local env)
FIFO Queue:
```
Queue "test-fifo-queue-local.fifo" exists with URL & ARN: [url: "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/test-fifo-queue-local.fifo", arn: "arn:aws:sqs:us-east-1:000000000000:test-fifo-queue-local.fifo"]
```

Standard Queue:
```
Queue "test-queue-local" exists with URL & ARN: [url: "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/test-queue-local", arn: "arn:aws:sqs:us-east-1:000000000000:test-queue-local"]
```

FIFO Topics:
```
Topic "test-fifo-topic-local.fifo" exists with ARN: "arn:aws:sns:us-east-1:000000000000:test-fifo-topic-local.fifo"
Topic "another-fifo-topic-local.fifo" exists with ARN: "arn:aws:sns:us-east-1:000000000000:another-fifo-topic-local.fifo"
```

Standard Topic:
```
Topic "test-standard-topic-local" exists with ARN: "arn:aws:sns:us-east-1:000000000000:test-standard-topic-local"
```
### Screenshots

### Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [X] I have tested this code
- [ ] If this is a bugfix, I've added testing to check this in the future
- [ ] I have updated the Readme
- [ ] I have added appropriate logging at the correct levels

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds FIFO support for AWS resources**
> 
> - Introduces `ResourceName` with `is_fifo` and `with_suffix` to correctly suffix env names before `.fifo`
> - `create_topic` now sets `FifoTopic=true` for FIFO topics and uses FIFO-aware name suffixing
> - `create_queue` uses FIFO-aware name suffixing, sets `FifoQueue=true` and `ContentBasedDeduplication=false` for FIFO queues, and updates the policy `aws:SourceArn` pattern to include `.fifo` when applicable
> - Minor refactor to use request builders before `send()` for both SNS and SQS creations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0516b57b9620eec070f36601d305fab875ca8625. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->